### PR TITLE
Add support for Postmark and SendGrid APIs

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+use Cake\Database\Type;
+
+Type::map('cake_email', 'Gourmet\Email\Database\Type\CakeEmailType');

--- a/src/Database/Type/CakeEmailType.php
+++ b/src/Database/Type/CakeEmailType.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Gourmet\Email\Database\Type;
+
+use Cake\Database\Driver;
+use Cake\Database\Type;
+use Cake\Network\Email\Email;
+use PDO;
+
+class CakeEmailType extends Type
+{
+    public function toPHP($value, Driver $driver)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $email = new Email();
+        $config = json_decode($value, true);
+
+        foreach ($config as $k => $v) {
+            switch ($k) {
+                case 'template':
+                    $email->template($v['template'], $v['layout']);
+                    continue;
+
+                case 'getHeaders':
+                    $k = 'setHeaders';
+                    $v = array_filter($v, function ($value) use ($v) {
+                        $array = array_flip($v);
+                        return !in_array($array[$value], [
+                            'Message-ID',
+                            'MIME-Version',
+                            'Content-Type',
+                            'Content-Transfer-Encoding'
+                        ]);
+                    });
+
+                default:
+                    $email->{$k}($v);
+            }
+        }
+        return $email;
+    }
+
+    public function toDatabase($value, Driver $driver)
+    {
+        if (!($value instanceof Email)) {
+            throw new \Exception();
+        }
+
+        $methods = [
+            'to', 'from', 'replyTo', 'cc', 'bcc', 'subject', 'returnPath', 'readReceipt',
+            'template', 'viewRender', 'viewVars', 'theme', 'helpers', 'emailFormat', 'transport',
+            'attachments', 'domain', 'messageId', 'getHeaders', 'charset', 'headerCharset',
+        ];
+
+        foreach ($methods as $k) {
+            $email[$k] = $value->{$k}();
+        }
+
+        return json_encode(array_filter($email));
+    }
+
+    public function toStatement($value, Driver $driver)
+    {
+        if ($value === null) {
+            return PDO::PARAM_NULL;
+        }
+        return PDO::PARAM_STR;
+    }
+}

--- a/src/Model/Table/EmailQueuesTable.php
+++ b/src/Model/Table/EmailQueuesTable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Gourmet\Email\Model\Table;
+
+use Cake\Database\Schema\Table as Schema;
+use Cake\ORM\Table;
+
+class EmailQueuesTable extends Table
+{
+    protected function _initializeSchema(Schema $schema)
+    {
+        $schema->columnType('email', 'email_json');
+        return $schema;
+    }
+}

--- a/src/Network/Email/AbstractApiTransport.php
+++ b/src/Network/Email/AbstractApiTransport.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Gourmet\Email\Network\Email;
+
+use Cake\Network\Email\AbstractTransport;
+use Cake\Network\Email\Email;
+use Cake\Network\Http\Client;
+
+abstract class AbstractApiTransport extends AbstractTransport
+{
+    /**
+     * API's expected request method.
+     *
+     * @var string
+     */
+    protected $_apiRequestMethod = 'POST';
+
+    /**
+     * API's endpoint.
+     *
+     * @var string
+     */
+    protected $_apiEndpoint;
+
+    /**
+     * Email instance.
+     *
+     * @var \Cake\Network\Email\Email
+     */
+    protected $_cakeEmail;
+
+    /**
+     * The response of the last API request.
+     *
+     * @var array
+     */
+    protected $_lastResponse = [];
+
+    /**
+     * The last message sent through the API.
+     *
+     * @var array
+     */
+    protected $_message;
+
+    /**
+     * Sends email.
+     *
+     * @param \Cake\Network\Email $email Cake email instance.
+     * @return array Formatted response.
+     */
+    public function send(Email $email)
+    {
+        $this->_cakeEmail = $email;
+        $this->_headers = $email->getHeaders(['from', 'sender', 'replyTo', 'readReceipt', 'to', 'cc', 'subject']);
+
+        $client = $this->_prepareHttpClient();
+        $method = strtolower($this->_apiRequestMethod);
+
+        $endpoint = $this->_apiEndpoint;
+        $payload = $this->_preparePayload();
+        $options = $this->_prepareRequestOptions();
+
+        $this->_lastResponse = $this->_handleResponse($client->{$method}($endpoint, $payload, $options));
+
+        return [
+            'headers' => $this->_headersToString($this->_headers),
+            'message' => $this->_message
+        ];
+    }
+
+    /**
+     * Gets HTTP client used to process requests.
+     *
+     * @return \Cake\Network\Http\Client Client.
+     */
+    protected function _prepareHttpClient()
+    {
+        $client = $this->config('client');
+
+        if (empty($client)) {
+            $client = [
+                'host' => $this->config('host'),
+                'scheme' => $this->config('ssl') ? 'https' : 'http',
+            ];
+        }
+
+        if (is_array($client)) {
+            $client = new Client($client);
+        }
+
+        if (!($client instanceof Client)) {
+            throw new \Exception();
+        }
+
+        return $client;
+    }
+
+    /**
+     * Cleans up the message ID.
+     *
+     * @return string.
+     */
+    protected function _prepareMessageId()
+    {
+        return substr($this->_headers['Message-ID'], 1, -1);
+    }
+
+    /**
+     * Returns extra options to use by the client when executing the request.
+     *
+     * @return array Request options.
+     */
+    protected function _prepareRequestOptions()
+    {
+        return [];
+    }
+
+    /**
+     * Checks headers to see if it's a batch request.
+     *
+     * @return bool True if it is.
+     */
+    protected function _isBatchRequest()
+    {
+        return false;
+    }
+
+    /**
+     * Checks headers to see if it's a tagged request.
+     *
+     * @return mixed False if not, tag otherwise.
+     */
+    protected function _isTaggedRequest()
+    {
+        return false;
+    }
+
+    /**
+     * Concatenate's message's lines into string.
+     *
+     * @param string $format Either text or html.
+     * @return string Message body.
+     */
+    protected function _messageToString($format)
+    {
+        return $this->_message[$format] = implode("\r\n", $this->_cakeEmail->message($format));
+    }
+
+    /**
+     * Prepares API payload in a supported format.
+     *
+     * @return mixed Payload.
+     */
+    abstract protected function _preparePayload();
+
+    /**
+     * Handles the API response.
+     *
+     * @param string $response Raw API response.
+     * @return array Decoded response.
+     */
+    abstract protected function _handleResponse($response);
+}

--- a/src/Network/Email/AbstractApiTransport.php
+++ b/src/Network/Email/AbstractApiTransport.php
@@ -133,7 +133,13 @@ abstract class AbstractApiTransport extends AbstractTransport
      */
     protected function _isTaggedRequest()
     {
-        return false;
+        $tag = !empty($this->_headers['X-Tag']);
+
+        if ($tag && $tag = $this->_headers['X-Tag']) {
+            unset($this->_headers['X-Tag']);
+        }
+
+        return $tag;
     }
 
     /**

--- a/src/Network/Email/AbstractQueueTransport.php
+++ b/src/Network/Email/AbstractQueueTransport.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Gourmet\Email\Network\Email;
+
+use Cake\Network\Email\AbstractTransport;
+use Cake\Network\Email\Email;
+
+abstract class AbstractQueueTransport extends AbstractTransport
+{
+    protected $_headers;
+    protected $_message;
+
+    public function send(Email $email)
+    {
+        $this->_cakeEmail = $email;
+        $this->_headers = $email->getHeaders(['from', 'sender', 'replyTo', 'readReceipt', 'to', 'cc', 'subject']);
+
+        $message = $this->_push();
+
+        return [
+            'headers' => $this->_headersToString($this->_headers),
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * Push email to queue.
+     *
+     * @return array Queued message in text, html or both.
+     */
+    abstract protected function _push();
+
+    protected function _getProfile()
+    {
+        $profile = $this->config('profile');
+
+        if (empty($profile)) {
+            throw new QueueTransportException();
+        }
+
+        if ($profile == $this->_cakeEmail->profile()) {
+            throw new QueueTransportException();
+        }
+
+        return $profile;
+    }
+
+    /**
+    * Concatenate's message's lines into string.
+    *
+    * @param string $format Either text or html.
+    * @return string Message body.
+    */
+    protected function _messageToString($format)
+    {
+        return $this->_message[$format] = implode("\r\n", $this->_cakeEmail->message($format));
+    }
+
+}

--- a/src/Network/Email/DatabaseQueueTransport.php
+++ b/src/Network/Email/DatabaseQueueTransport.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Gourmet\Email\Network\Email;
+
+use Cake\ORM\TableRegistry;
+use Gourmet\Email\Network\Exception\QueueTransportException;
+use Gourmet\Email\Network\Exception\QueueTransportUnknownException;
+use Gourmet\Email\Model\Table\EmailQueuesTable;
+
+class DatabaseQueueTransport extends AbstractQueueTransport
+{
+    protected $_defaultConfig = [
+        'model' => 'Gourmet/Email.EmailQueues',
+        'profile' => null,
+    ];
+
+    /**
+     * Push email to queue.
+     *
+     * @return array Queued message in text, html or both.
+     */
+    protected function _push()
+    {
+        $table = TableRegistry::get($this->config('model'));
+
+        if (!($table instanceof EmailQueuesTable)) {
+            throw new QueueTransportException();
+        }
+
+        $data = [
+            'profile' => $this->_getProfile(),
+            'send_at' => $this->_headers['Date'],
+            '_email' => $this->_cakeEmail
+        ];
+
+        $email = $table->newEntity($data);
+        if (!$table->save($email)) {
+            throw new QueueTransportUnknownException($email);
+        }
+
+        $format = $this->_cakeEmail->emailFormat();
+        if (in_array($format, ['html', 'both'])) {
+            $message['html'] = $this->_messageToString('html');
+        }
+        if (in_array($format, ['text', 'both'])) {
+            $message['text'] = $this->_messageToString('text');
+        }
+
+        return $message;
+    }
+}

--- a/src/Network/Email/PostmarkApiTransport.php
+++ b/src/Network/Email/PostmarkApiTransport.php
@@ -145,7 +145,7 @@ class PostmarkApiTransport extends AbstractApiTransport
     /**
      * Builds attachments' part of the payload.
      *
-     * @return array
+     * @return array Attachments' payload.
      */
     protected function _buildAttachments()
     {
@@ -178,9 +178,9 @@ class PostmarkApiTransport extends AbstractApiTransport
     }
 
     /**
-     * Handles API response.
+     * Handles the API response.
      *
-     * @return bool True if the request was successful.
+     * @return array Decoded response.
      * @link http://developer.postmarkapp.com/developer-api-overview.html#error-codes
      */
     protected function _handleResponse($response)

--- a/src/Network/Email/PostmarkApiTransport.php
+++ b/src/Network/Email/PostmarkApiTransport.php
@@ -105,9 +105,8 @@ class PostmarkApiTransport extends AbstractApiTransport
         ];
 
         // Tag
-        if ($tag = $this->_headers['X-Tag']) {
+        if ($tag = $this->_isTaggedRequest()) {
             $message['Tag'] = $tag;
-            unset($this->_headers['X-Tag']);
         }
 
         // Body

--- a/src/Network/Email/PostmarkApiTransport.php
+++ b/src/Network/Email/PostmarkApiTransport.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Gourmet\Email\Network\Email;
+
+use Cake\Network\Email\Email;
+use Gourmet\Email\Network\Exception\ApiTransportException;
+use Gourmet\Email\Network\Exception\ApiTransportLimitException;
+use Gourmet\Email\Network\Exception\ApiTransportUnknownException;
+
+/**
+ * Postmark API Transport.
+ *
+ * Transparently send emails using the Postmark API. While the implementation is
+ * complete, there are a few things one needs to be aware of:
+ *
+ *    - You MUST have a registered and confirmed sender signature with the sender email.
+ *    - A single email MUST not have more than 20 recipients (to + cc + bcc)
+ *    - ONLY the `From` and `To` are able to accept recipients' names.
+ *    - `TextBody` and `HtmlBody` are limited to 5MB each.
+ *    - `Attachements` can be up to 10MB (one or all together).
+ *
+ * @link http://developer.postmarkapp.com/developer-send-api.html
+ */
+class PostmarkApiTransport extends AbstractApiTransport
+{
+    /**
+     * Maximum allowed number of recipients.
+     *
+     * @var int
+     */
+    const MAX_ALLOWED_RECIPIENTS = 20;
+
+    /**
+     * API's endpoint.
+     *
+     * @var string
+     */
+    protected $_apiEndpoint = 'email';
+
+    /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'host' => 'api.postmarkapp.com',
+        'ssl' => true,
+        'token' => null,
+        'trackOpens' => true,
+        'debug' => false,
+    ];
+
+    /**
+     * Returns extra options to use by the client when executing the request.
+     *
+     * @return array
+     */
+    protected function _prepareRequestOptions()
+    {
+        $token = $this->config('token');
+
+        if ($this->config('test')) {
+            $token = 'POSTMARK_API_TEST';
+        }
+
+        return [
+            'header' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'X-Postmark-Server-Token' => $token,
+            ]
+        ];
+    }
+
+    /**
+     * Format CC and BCC according to API spec.
+     *
+     * @param string $recipientType One of 'cc' or 'bcc'.
+     * @return string Comma-separated list of emails (no names).
+     */
+    protected function _prepareRecipientAddress($recipientType)
+    {
+        $method = strtolower($recipientType);
+        return implode(',', array_keys($this->_cakeEmail->{$method}()));
+    }
+
+    /**
+     * Prepares API payload in a supported format.
+     *
+     * @return mixed Payload.
+     * @link http://developer.postmarkapp.com/developer-api-email.html
+     * @todo batch
+     */
+    protected function _preparePayload()
+    {
+        $this->_validate();
+
+        // Common
+        $message = [
+            'From' => $this->_headers['From'],
+            'To' => $this->_headers['To'],
+            'Cc' => $this->_prepareRecipientAddress('cc'),
+            'Bcc' => $this->_prepareRecipientAddress('bcc'),
+            'Subject' => mb_decode_mimeheader($this->_headers['Subject']),
+        ];
+
+        // Tag
+        if ($tag = $this->_headers['X-Tag']) {
+            $message['Tag'] = $tag;
+            unset($this->_headers['X-Tag']);
+        }
+
+        // Body
+        $format = $this->_cakeEmail->emailFormat();
+        if (in_array($format, ['html', 'both'])) {
+            $message['HtmlBody'] = $this->_messageToString('html');
+        }
+        if (in_array($format, ['text', 'both'])) {
+            $message['TextBody'] = $this->_messageToString('text');
+        }
+
+        // ReplyTo
+        if ($replyTo = $this->_headers['Reply-To']) {
+            $message['ReplyTo'] = $replyTo;
+        }
+
+        // Headers
+        $message['Headers'] = ['MessageID' => $this->_prepareMessageId()];
+        foreach ($this->_headers as $k => $v) {
+            if (strpos($k, 'X-') === 0) {
+                $message['Headers'][$k] = $v;
+            }
+        }
+
+        // Tracking
+        if ($trackOpens = $this->config('trackOpens')) {
+            $message['TrackOpens'] = $trackOpens;
+        }
+
+        // Attachments
+        $message['Attachments'] = $this->_buildAttachments();
+
+        return json_encode($message);
+    }
+
+    /**
+     * Builds attachments' part of the payload.
+     *
+     * @return array
+     */
+    protected function _buildAttachments()
+    {
+        $attachments = [];
+        $i = 0;
+
+        foreach ($this->_cakeEmail->attachments() as $file => $info) {
+            $attachments[$i] = [
+                'Name' => $file,
+                'ContentType' => $info['mimetype'],
+            ];
+
+            if (isset($info['file'])) {
+                $fh = fopen($info['file'], 'rb');
+                $data = chunk_split(base64_encode(fread($fh, filesize($info['file']))));
+                fclose($fh);
+                $attachments[$i]['Content'] = $data;
+            } else if (isset($info['data'])) {
+                $attachments[$i]['Content'] = $info['data'];
+            }
+
+            if (isset($info['contentId'])) {
+                $attachments[$i]['ContentId'] = $info['contentId'];
+            }
+
+            $i++;
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * Handles API response.
+     *
+     * @return bool True if the request was successful.
+     * @link http://developer.postmarkapp.com/developer-api-overview.html#error-codes
+     */
+    protected function _handleResponse($response)
+    {
+        if (empty($response) || !$decoded = (array) @json_decode($response)) {
+            // something went wrong
+            throw new ApiTransportUnknownException('Postmark');
+        }
+
+        // Is 422?
+        if ($decoded['ErrorCode']) {
+            throw new ApiTransportException(
+                $decoded['Message'],
+                $decoded['ErrorCode']
+            );
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Validates a send request not to exceed the maximum allowed number of
+     * recipients.
+     *
+     * @return void
+     */
+    protected function _validate()
+    {
+        $count = count($this->_cakeEmail->to())
+            + count($this->_cakeEmail->cc())
+            + count($this->_cakeEmail->bcc());
+
+        if ($count > self::MAX_ALLOWED_RECIPIENTS) {
+            throw new ApiTransportLimitException(self::MAX_ALLOWED_RECIPIENTS);
+        }
+    }
+}

--- a/src/Network/Email/SendGridApiTransport.php
+++ b/src/Network/Email/SendGridApiTransport.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Gourmet\Email\Network\Email;
+
+use Cake\Network\Email\Email;
+use Gourmet\Email\Network\Exception\ApiTransportException;
+use Gourmet\Email\Network\Exception\ApiTransportUnknownException;
+
+/**
+ * SendGrid API Transport.
+ *
+ * Transparently send emails using the SendGrid API.
+ *
+ * @link https://sendgrid.com/docs/API_Reference/Web_API/mail.html
+ * @todo debug mode
+ */
+class SendGridApiTransport extends AbstractApiTransport
+{
+    /**
+     * API's endpoint.
+     *
+     * @var string
+     */
+    protected $_apiEndpoint = 'mail.send.json';
+
+    /**
+     * Default configuration.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'host' => 'api.sendgrid.com/api',
+        'ssl' => true,
+        'apiUser' => null,
+        'apiKey' => null,
+        'debug' => false,
+    ];
+
+    /**
+     * Prepares API payload in a supported format.
+     *
+     * @return array Payload.
+     * @todo inline media content, batch
+     */
+    protected function _preparePayload()
+    {
+        // Auth
+        $payload = [
+            'api_user' => $this->config('apiUser'),
+            'api_key' => $this->config('apiKey'),
+        ];
+
+        // Main recipient(s)
+        $payload += $this->_prepareRecipientAddress('to');
+
+        // Subject
+        $payload['subject'] = mb_decode_mimeheader($this->_headers['Subject']);
+
+        // From
+        $payload += $this->_prepareRecipientAddress('from');
+
+        // Body
+        $format = $this->_cakeEmail->emailFormat();
+        if (in_array($format, ['html', 'both'])) {
+            $payload['html'] = implode('', $this->_cakeEmail->message('html'));
+        }
+        if (in_array($format, ['text', 'both'])) {
+            $payload['text'] = $this->_messageToString('text');
+        }
+
+        // Extra recipients
+        $payload += $this->_prepareRecipientAddress('cc');
+        $payload += $this->_prepareRecipientAddress('bcc');
+
+        // ReplyTo
+        if ($replyTo = $this->_cakeEmail->replyTo()) {
+            $payload['replyto'] = current(array_keys($replyTo));
+        }
+
+        // Headers
+        $payload['headers'] = ['MessageID' => $this->_prepareMessageId()];
+        foreach ($this->_headers as $k => $v) {
+            if ('X-Tag' == $k) {
+                $payload['x-smtpapi']['category'] = $v;
+                continue;
+            }
+            if (strpos($k, 'x-smtpapi') === 0) {
+                $payload['x-smtpapi'][$k] = $v;
+                continue;
+            }
+            if (strpos($k, 'X-') === 0) {
+                $payload['headers'][$k] = $v;
+            }
+        }
+
+        // Attachments
+        foreach ((array) $this->_cakeEmail->attachments() as $file => $info) {
+            $payload['files[' . $file . ']'] = '@' . $info['file'];
+        }
+
+        foreach (['x-smtpapi', 'headers'] as $k) {
+            if (!empty($payload[$k])) {
+                $payload[$k] = json_encode($payload[$k]);
+            }
+        }
+
+        return array_filter($payload);
+    }
+
+    /**
+     * Prepare payload for recipients of all types according to API specs.
+     *
+     * @param string $recipientType One of `to`, `from`, `cc`, `bcc`.
+     * @return array Payload.
+     */
+    protected function _prepareRecipientAddress($recipientType)
+    {
+        $method = strtolower($recipientType);
+        $recipients = $this->_cakeEmail->{$method}();
+
+        $nonames = $emails = $names = [];
+        foreach ($recipients as $email => $name) {
+            if ($email == $name) {
+                $nonames[] = $email;
+                continue;
+            }
+            $emails[] = $email;
+            $names[] = $name;
+        }
+
+        $emails = array_merge($emails, $nonames);
+
+        $payload = [
+            $recipientType => $emails,
+            $recipientType . 'name' => $names
+        ];
+
+        if (count($emails) === 1) {
+            $payload = [
+                $recipientType => current($emails),
+                $recipientType . 'name' => current($names),
+            ];
+        }
+
+        return array_filter($payload);
+    }
+
+    /**
+     * Builds attachments' part of the payload.
+     *
+     * @return array
+     */
+    protected function _buildAttachments()
+    {
+        $attachments = [];
+        $i = 0;
+
+        foreach ($this->_cakeEmail->attachments() as $file => $info) {
+            // TODO complete
+        }
+
+        return $attachments;
+    }
+
+    /**
+     * Handles API response.
+     *
+     * @return bool True if the request was successful.
+     */
+    protected function _handleResponse($response)
+    {
+        if (empty($response) || !$decoded = (array) @json_decode($response)) {
+            // something went wrong
+            throw new ApiTransportUnknownException('SendGrid');
+        }
+
+        // has errors?
+        if ('success' != $decoded['message']) {
+            $error = array_shift($decoded['error']);
+            throw new ApiTransportException(
+                $error,
+                400 // FIXME retrieve response code from client
+            );
+        }
+
+        return $decoded;
+    }
+}

--- a/src/Network/Email/SendGridApiTransport.php
+++ b/src/Network/Email/SendGridApiTransport.php
@@ -50,6 +50,11 @@ class SendGridApiTransport extends AbstractApiTransport
             'api_key' => $this->config('apiKey'),
         ];
 
+        // Category
+        if ($tag = $this->_isTaggedRequest()) {
+            $payload['x-smtpapi']['category'] = $tag;
+        }
+
         // Main recipient(s)
         $payload += $this->_prepareRecipientAddress('to');
 
@@ -80,10 +85,6 @@ class SendGridApiTransport extends AbstractApiTransport
         // Headers
         $payload['headers'] = ['MessageID' => $this->_prepareMessageId()];
         foreach ($this->_headers as $k => $v) {
-            if ('X-Tag' == $k) {
-                $payload['x-smtpapi']['category'] = $v;
-                continue;
-            }
             if (strpos($k, 'x-smtpapi') === 0) {
                 $payload['x-smtpapi'][$k] = $v;
                 continue;

--- a/src/Network/Email/SendGridApiTransport.php
+++ b/src/Network/Email/SendGridApiTransport.php
@@ -149,7 +149,7 @@ class SendGridApiTransport extends AbstractApiTransport
     /**
      * Builds attachments' part of the payload.
      *
-     * @return array
+     * @return array Attachments' payload.
      */
     protected function _buildAttachments()
     {
@@ -164,9 +164,9 @@ class SendGridApiTransport extends AbstractApiTransport
     }
 
     /**
-     * Handles API response.
+     * Handles the API response.
      *
-     * @return bool True if the request was successful.
+     * @return array Decoded response.
      */
     protected function _handleResponse($response)
     {

--- a/src/Network/Email/SendGridApiTransport.php
+++ b/src/Network/Email/SendGridApiTransport.php
@@ -147,23 +147,6 @@ class SendGridApiTransport extends AbstractApiTransport
     }
 
     /**
-     * Builds attachments' part of the payload.
-     *
-     * @return array Attachments' payload.
-     */
-    protected function _buildAttachments()
-    {
-        $attachments = [];
-        $i = 0;
-
-        foreach ($this->_cakeEmail->attachments() as $file => $info) {
-            // TODO complete
-        }
-
-        return $attachments;
-    }
-
-    /**
      * Handles the API response.
      *
      * @return array Decoded response.

--- a/src/Network/Exception/ApiTransportException.php
+++ b/src/Network/Exception/ApiTransportException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Gourmet\Email\Network\Exception;
+
+use Cake\Core\Exception\Exception;
+
+class ApiTransportException extends Exception
+{
+}

--- a/src/Network/Exception/ApiTransportLimitException.php
+++ b/src/Network/Exception/ApiTransportLimitException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Gourmet\Email\Network\Exception;
+
+class ApiTransportLimitException extends ApiTransportException
+{
+    protected $_messageTemplate = 'Exceeded maximum allowed number of recipients (%s).';
+}

--- a/src/Network/Exception/ApiTransportUnknownException.php
+++ b/src/Network/Exception/ApiTransportUnknownException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Gourmet\Email\Network\Exception;
+
+class ApiTransportUnknownException extends ApiTransportException
+{
+    protected $_messageTemplate = 'Unknown %s API transport exception.';
+}

--- a/tests/TestCase/Database/Type/CakeEmailTypeTest.php
+++ b/tests/TestCase/Database/Type/CakeEmailTypeTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Gourmet\Email\Test\TestCase\Database\Type;
+
+use Cake\Network\Email\Email;
+use Cake\TestSuite\TestCase;
+use Gourmet\Email\Database\Type\CakeEmailType;
+
+class CakeEmailTypeTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->CakeEmailType = new CakeEmailType('cake_email');
+        $this->Driver = $this->getMock('Cake\Database\Driver');
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        unset($this->CakeEmailType, $this->Driver);
+    }
+
+    protected function _getEmail($date)
+    {
+        $email = new Email();
+        $email->from('noreply@cakephp.org', 'CakePHP Test');
+        $email->returnPath('pleasereply@cakephp.org', 'CakePHP Return');
+        $email->to('cake@cakephp.org', 'CakePHP');
+        $email->cc(['mark@cakephp.org' => 'Mark Story, Jr.', 'juan@cakephp.org' => 'Juan Basso']);
+        $email->bcc('phpnut@cakephp.org');
+        $email->emailFormat('html');
+        $email->messageID('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
+        $email->subject('Testing Queue');
+        $email->setHeaders([
+            'X-Mailer' => 'CakePHP Email',
+            'Date' => $date,
+            'X-Tag' => 'sometag',
+        ]);
+        $email->domain('test.email');
+        $email->template('default', 'default1');
+        return $email;
+    }
+
+    protected function _getEmailConfig($date)
+    {
+        return [
+            'to' => ['cake@cakephp.org' => 'CakePHP'],
+            'from' => ['noreply@cakephp.org' => 'CakePHP Test'],
+            'cc' => [
+                'mark@cakephp.org' => 'Mark Story, Jr.',
+                'juan@cakephp.org' => 'Juan Basso',
+            ],
+            'bcc' => ['phpnut@cakephp.org' => 'phpnut@cakephp.org'],
+            'subject' => 'Testing Queue',
+            'returnPath' => ['pleasereply@cakephp.org' => 'CakePHP Return'],
+            'template' => ['template' => 'default', 'layout' => 'default1'],
+            'viewRender' => 'Cake\\View\\View',
+            'helpers' => ['Html'],
+            'emailFormat' => 'html',
+            'domain' => 'test.email',
+            'messageId' => '<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>',
+            'getHeaders' => [
+                'X-Mailer' => 'CakePHP Email',
+                'Date' => $date,
+                'X-Tag' => 'sometag',
+                'Message-ID' => '<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>',
+                'MIME-Version' => '1.0',
+                'Content-Type' => 'text/html; charset=UTF-8',
+                'Content-Transfer-Encoding' => '8bit',
+            ],
+            'charset' => 'UTF-8',
+            'headerCharset' => 'UTF-8'
+        ];
+    }
+
+    public function testToPHP()
+    {
+        $date = gmdate('Y-m-d H:i:s');
+        $value = json_encode($this->_getEmailConfig($date));
+        $result = $this->CakeEmailType->toPHP($value, $this->Driver);
+        $expected = $this->_getEmail($date);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testToDatabase()
+    {
+        $date = gmdate('Y-m-d H:i:s');
+        $value = $this->_getEmail($date);
+        $result = $this->CakeEmailType->toDatabase($value, $this->Driver);
+        $expected = json_encode($this->_getEmailConfig($date));
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/TestCase/Network/Email/DatabaseQueueTransportTest.php
+++ b/tests/TestCase/Network/Email/DatabaseQueueTransportTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Gourmet\Email\Test\TestCase\Network\Email;
+
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+use Gourmet\Email\Network\Email\DatabaseQueueTransport;
+
+class DatabaseQueueTransportTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->EmailQueues = $this->getMock('Gourmet\Email\Model\Table\EmailQueuesTable', ['newEntity', 'save']);
+        TableRegistry::set('Gourmet/Email.EmailQueues', $this->EmailQueues);
+
+        $this->Queue = new DatabaseQueueTransport([
+            'profile' => 'foo',
+        ]);
+    }
+
+    protected function _getEmailMock($date)
+    {
+        $email = $this->getMock('Cake\Network\Email\Email', ['message']);
+        $email->from('noreply@cakephp.org', 'CakePHP Test');
+        $email->returnPath('pleasereply@cakephp.org', 'CakePHP Return');
+        $email->to('cake@cakephp.org', 'CakePHP');
+        $email->cc(['mark@cakephp.org' => 'Mark Story, Jr.', 'juan@cakephp.org' => 'Juan Basso']);
+        $email->bcc('phpnut@cakephp.org');
+        $email->emailFormat('html');
+        $email->messageID('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
+        $email->subject('Testing Queue');
+        $email->setHeaders([
+            'X-Mailer' => 'CakePHP Email',
+            'Date' => $date,
+            'X-Tag' => 'sometag',
+        ]);
+        $email->expects($this->at(0))
+            ->method('message')
+            ->with('html')
+            ->will($this->returnValue(['First Line', 'Second Line', '.Third Line', '']));
+
+        return $email;
+    }
+
+    public function testSend()
+    {
+        $date = gmdate('Y-m-d H:i:s');
+        $cakeEmail = $this->_getEmailMock($date);
+        $emailEntity = $this->getMock('Cake\ORM\Entity');
+
+        $data = [
+            'profile' => 'foo',
+            'send_at' => $date,
+            '_email' => $cakeEmail
+        ];
+
+        $this->EmailQueues->expects($this->once())
+            ->method('newEntity')
+            ->with($data)
+            ->will($this->returnValue($emailEntity));
+
+        $this->EmailQueues->expects($this->once())
+            ->method('save')
+            ->with($emailEntity)
+            ->will($this->returnValue(true));
+
+        $result = $this->Queue->send($cakeEmail);
+        $this->assertTrue(is_array($result));
+    }
+
+}

--- a/tests/TestCase/Network/Email/PostmarkApiTransportTest.php
+++ b/tests/TestCase/Network/Email/PostmarkApiTransportTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Gourmet\Email\Test\TestCase\Network\Email;
+
+use Cake\Network\Email\Email;
+use Cake\TestSuite\TestCase;
+use Gourmet\Email\Network\Email\PostmarkApiTransport;
+
+class PostmarkApiTransportTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->date = date(DATE_RFC2822);
+        $this->Client = $this->getMock('Cake\Network\Http\Client', ['post']);
+        $this->Postmark = new PostmarkApiTransport([
+            'client' => $this->Client,
+            'token' => 'foo',
+        ]);
+    }
+
+    protected function _getEmailMock($methods = ['message'])
+    {
+        $email = $this->getMock('Cake\Network\Email\Email', $methods);
+        $email->from('noreply@cakephp.org', 'CakePHP Test');
+        $email->returnPath('pleasereply@cakephp.org', 'CakePHP Return');
+        $email->to('cake@cakephp.org', 'CakePHP');
+        $email->cc(['mark@cakephp.org' => 'Mark Story, Jr.', 'juan@cakephp.org' => 'Juan Basso']);
+        $email->bcc('phpnut@cakephp.org');
+        $email->emailFormat('html');
+        $email->messageID('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
+        $email->subject('Testing SMTP');
+        $email->setHeaders([
+            'X-Mailer' => Email::EMAIL_CLIENT,
+            'Date' => $this->date,
+            'X-Tag' => 'sometag',
+        ]);
+        $email->expects($this->at(0))
+            ->method('message')
+            ->with('html')
+            ->will($this->returnValue(['First Line', 'Second Line', '.Third Line', '']));
+
+        return $email;
+    }
+
+    public function testSend()
+    {
+        $email = $this->_getEmailMock();
+
+        $options = ['header' => [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'X-Postmark-Server-Token' => 'foo',
+        ]];
+
+        $data = json_encode([
+            'From' => 'CakePHP Test <noreply@cakephp.org>',
+            'To' => 'CakePHP <cake@cakephp.org>',
+            'Cc' => 'mark@cakephp.org,juan@cakephp.org',
+            'Bcc' => 'phpnut@cakephp.org',
+            'Subject' => 'Testing SMTP',
+            'Tag' => 'sometag',
+            'HtmlBody' => implode("\r\n", ['First Line', 'Second Line', '.Third Line', '']),
+            'Headers' => [
+                'MessageID' => '4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost',
+                'X-Mailer' => 'CakePHP Email',
+            ],
+            'TrackOpens' => true,
+            'Attachments' => [],
+        ]);
+
+        $response = json_encode([
+            'ErrorCode' => 0,
+            'Message' => 'OK',
+            'MessageID' => '4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost',
+            'SubmittedAt' => '',
+            'To' => 'cake@cakephp.org',
+        ]);
+
+
+        $this->Client->expects($this->once())
+            ->method('post')
+            ->with('email', $data, $options)
+            ->will($this->returnValue($response));
+
+        $result = $this->Postmark->send($email);
+        $this->assertTrue(is_array($result));
+    }
+
+}

--- a/tests/TestCase/Network/Email/PostmarkApiTransportTest.php
+++ b/tests/TestCase/Network/Email/PostmarkApiTransportTest.php
@@ -31,7 +31,7 @@ class PostmarkApiTransportTest extends TestCase
         $email->messageID('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
         $email->subject('Testing SMTP');
         $email->setHeaders([
-            'X-Mailer' => Email::EMAIL_CLIENT,
+            'X-Mailer' => 'CakePHP Email',
             'Date' => $this->date,
             'X-Tag' => 'sometag',
         ]);

--- a/tests/TestCase/Network/Email/SendGridApiTransportTest.php
+++ b/tests/TestCase/Network/Email/SendGridApiTransportTest.php
@@ -32,7 +32,7 @@ class SendGridApiTransportTest extends TestCase
         $email->messageID('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
         $email->subject('Testing API');
         $email->setHeaders([
-            'X-Mailer' => Email::EMAIL_CLIENT,
+            'X-Mailer' => 'CakePHP Email',
             'X-Tag' => 'sometag',
         ]);
         $email->expects($this->at(0))

--- a/tests/TestCase/Network/Email/SendGridApiTransportTest.php
+++ b/tests/TestCase/Network/Email/SendGridApiTransportTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Gourmet\Email\Test\TestCase\Network\Email;
+
+use Cake\Network\Email\Email;
+use Cake\TestSuite\TestCase;
+use Gourmet\Email\Network\Email\SendGridApiTransport;
+
+class SendGridApiTransportTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->Client = $this->getMock('Cake\Network\Http\Client', ['post']);
+        $this->SendGrid = new SendGridApiTransport([
+            'client' => $this->Client,
+            'token' => 'foo',
+            'apiUser' => 'testuser',
+            'apiKey' => 'testkey',
+        ]);
+    }
+
+    protected function _getEmailMock($methods = ['message'])
+    {
+        $email = $this->getMock('Cake\Network\Email\Email', $methods);
+        $email->from('noreply@cakephp.org', 'CakePHP Test');
+        $email->returnPath('pleasereply@cakephp.org', 'CakePHP Return');
+        $email->to('cake@cakephp.org', 'CakePHP');
+        $email->cc(['mark@cakephp.org' => 'Mark Story', 'juan@cakephp.org' => 'Juan Basso']);
+        $email->bcc('phpnut@cakephp.org');
+        $email->emailFormat('html');
+        $email->messageID('<4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost>');
+        $email->subject('Testing API');
+        $email->setHeaders([
+            'X-Mailer' => Email::EMAIL_CLIENT,
+            'X-Tag' => 'sometag',
+        ]);
+        $email->expects($this->at(0))
+            ->method('message')
+            ->with('html')
+            ->will($this->returnValue(['First Line', 'Second Line', '.Third Line', '']));
+
+        return $email;
+    }
+
+    public function testSend()
+    {
+        $email = $this->_getEmailMock();
+
+        $data = [
+            'api_user' => 'testuser',
+            'api_key' => 'testkey',
+            'to' => 'cake@cakephp.org',
+            'toname' => 'CakePHP',
+            'subject' => 'Testing API',
+            'from' => 'noreply@cakephp.org',
+            'fromname' => 'CakePHP Test',
+            'html' => 'First LineSecond Line.Third Line',
+            'cc' => [
+                'mark@cakephp.org',
+                'juan@cakephp.org',
+            ],
+            'ccname' => [
+                'Mark Story',
+                'Juan Basso',
+            ],
+            'bcc' => 'phpnut@cakephp.org',
+            'headers' => json_encode([
+                'MessageID' => '4d9946cf-0a44-4907-88fe-1d0ccbdd56cb@localhost',
+                'X-Mailer' => 'CakePHP Email',
+            ]),
+            'x-smtpapi' => json_encode(['category' => 'sometag']),
+        ];
+
+        $response = json_encode([
+            'message' => 'success',
+        ]);
+
+
+        $this->Client->expects($this->once())
+            ->method('post')
+            ->with('mail.send.json', $data, [])
+            ->will($this->returnValue($response));
+
+        $result = $this->SendGrid->send($email);
+        $this->assertTrue(is_array($result));
+    }
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,4 +53,4 @@ Configure::write('App', [
 ]);
 
 
-Plugin::load('Gourmet/Email', ['path' => ROOT]);
+Plugin::load('Gourmet/Email', ['path' => ROOT, 'bootstrap' => true]);


### PR DESCRIPTION
Been asked a couple times why not just use SMTP. I thought it would be worth writing a little more in-depth explanation which should also keep me reminded of the real reasons that pushed me to code this for the current application I am working on.

While SMTP is great and PHP's native email function is super easy to get things started, there are other (and I believe better) solutions. The transports that are introduced in this PR are completely independent of each other and fill a single need in the general 'sending a transactional email' context/process.

Pros I find to using every transport type introduced:

**API**
- Performance: less interactions required by message (1 vs. 2+)
- Lower barrier: no need to have any SMTP requirements installed

**DatabaseQueue**
- Performance: sending of an email takes way more time than a database write (or any type of queuing)
- Fail-safe: database writes are transaction aware - if one operation fails, the entire transaction is rolled back
- Scalability: by modeling the email into queues, it becomes easier to scale in the future by re-implementing a different Queue transport (RabbitMQ, IronMQ, etc.) and leave the actual job to be handled by dedicated worker instances

_Note: the DatabaseQueue'd job can then use the `SmtpTransport` (or any `ApiTransport`) to send the email._

Any comments/feedback/critic on the above explanation/reasoning or the committed code/implementations below are welcomed (I most probably directly linked you to this page for that exact reason :dart: ).
